### PR TITLE
allow access list to be used

### DIFF
--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -55,10 +55,6 @@ export enum TxTypeToPrefix {
   eip1559 = 0x02,
 }
 
-function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
-  return accessListify(value).map((set) => [ set.address, set.storageKeys ]);
-}
-
 interface Field {
   maxLength?: number;
   length?: number;
@@ -344,7 +340,7 @@ export function parseCeloTransaction(rawTransaction: BytesLike): CeloTransaction
         to: handleAddress(transaction[5] as string),
         value: handleBigInt(transaction[6] as string),
         data: transaction[7] as string,
-        accessList: handleAccessList(transaction[8]),
+        accessList: handleAccessList(transaction[8] as Array<[ string, Array<string> ]>),
         feeCurrency: handleAddress(transaction[9] as string),
         maxFeeInFeeCurrency: handleBigInt(transaction[10] as string),
       } as CeloTransactionCip66;
@@ -360,7 +356,7 @@ export function parseCeloTransaction(rawTransaction: BytesLike): CeloTransaction
         to: handleAddress(transaction[5] as string),
         value: handleBigInt(transaction[6] as string),
         data: transaction[7],
-        accessList: handleAccessList(transaction[8] as string),
+        accessList: handleAccessList(transaction[8] as Array<[ string, Array<string> ]>),
         feeCurrency: handleAddress(transaction[9] as string),
       } as CeloTransactionCip64;
       break;
@@ -376,7 +372,7 @@ export function parseCeloTransaction(rawTransaction: BytesLike): CeloTransaction
         to: handleAddress(transaction[5] as string),
         value: handleBigInt(transaction[6] as string),
         data: transaction[7] as string,
-        accessList: handleAccessList(transaction[8] as string),
+        accessList: handleAccessList(transaction[8] as Array<[ string, Array<string> ]>),
       } as CeloTransactionEip1559;
       break;
     default:
@@ -474,11 +470,25 @@ function handleBigInt(value: string): bigint {
   return getBigInt(value);
 }
 
-function handleAccessList(value: any): AccessList {
+function formatAccessList(value: AccessListish): Array<[ string, Array<string> ]> {
+  return accessListify(value).map((set) => [ set.address, set.storageKeys ]);
+}
+
+/*
+@param value [
+      [
+        '0x0000000000000000000000000000000000000000',
+        [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe'
+        ]
+      ]
+    ]
+*/
+function handleAccessList(value: Array<[ string, Array<string> ]> | '0x'): AccessList {
   if (value === "0x") {
     return accessListify([]);
   }
-  // TODO: use value
   return accessListify(value);
 }
 

--- a/tests/transactions.unit.test.ts
+++ b/tests/transactions.unit.test.ts
@@ -17,6 +17,34 @@ describe('serializeCeloTransaction', () => {
 
     expect(serializeCeloTransaction(tx)).toMatchInlineSnapshot(`"0x7af84b82a4ec01847735940084773594008094f653a42ef024d174bb4be98b67690e5886d01f5f880de0b6b3a764000080c094765de816845861e75a25fca122bb6898b8b1282a860b3a4b56fa00"`);
   });
+  it('can handle accessList', () => {
+    const transaction = serializeCeloTransaction({
+      to: "0xF653A42ef024d174Bb4bE98B67690E5886d01F5F",
+      chainId: 42220,
+      nonce: 1,
+      accessList: [
+        {
+          address: '0x0000000000000000000000000000000000000000',
+          storageKeys: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          ],
+        },
+      ],
+    })
+    expect(transaction).toMatchInlineSnapshot(`"0x02f87b82a4ec0180808094f653a42ef024d174bb4be98b67690e5886d01f5f8080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"`)
+    expect(parseCeloTransaction(transaction).accessList).toMatchInlineSnapshot(`
+[
+  {
+    "address": "0x0000000000000000000000000000000000000000",
+    "storageKeys": [
+      "0x0000000000000000000000000000000000000000000000000000000000000001",
+      "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+    ],
+  },
+]
+`)
+  })
 });
 describe('parseCeloTransaction', () => {
   it('serializes CIP-66 transaction', () => {


### PR DESCRIPTION
Noticed that any supplied access list would be ignored both when parsing and serializing transactions